### PR TITLE
Feature/check exposure folder constraint

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -188,6 +188,12 @@
     entry: check-source-tags
     language: python
     types_or: [yaml]
+    id: check-exposure-folder-constraint
+    name: Check exposure folder constraint
+    description: Ensures exposures are only defined in a given folder X.
+    entry: check-exposure-folder-constraint
+    language: python
+    types_or: [yaml]
 -   id: dbt-clean
     name: dbt clean
     description: Deletes all folders specified in the clean-targets.

--- a/HOOKS.md
+++ b/HOOKS.md
@@ -7,6 +7,8 @@
 **Exposure checks:**
  * [`check-exposure-has-models`](https://github.com/artefactory/pre-commit-dbt/blob/main/HOOKS.md#check-exposure-has-models): Check if the exposures depends on at least one model
 
+ * [`check-exposure_folder_constraint`](https://github.com/artefactory/pre-commit-dbt/blob/main/HOOKS.md#check-exposure-folder-constraint): Ensures exposures are only defined in a given folder X.
+ 
 **Model checks:**
  * [`check-column-desc-are-same`](https://github.com/offbi/pre-commit-dbt/blob/main/HOOKS.md#check-column-desc-are-same): Check column descriptions are the same.
  * [`check-column-name-contract`](): Check column name abides to contract.
@@ -66,6 +68,30 @@
 :exclamation:**If you have an idea for a new hook or you found a bug, [let us know](https://github.com/offbi/pre-commit-dbt/issues/new)**:exclamation:
 
 ## Available Hooks
+### `check-exposure-folder-constraint`
+
+ * Checks if exposure definitions are placed in the directory, passed as argument.
+
+ #### Arguments
+
+`--folder-name`: Path to folder to be checked.
+
+ #### Example
+ ```
+ repos:
+ - repo: https://github.com/artefactory/pre-commit-dbt
+  rev: v1.0.0
+  hooks:
+  - id: check-exposure-folder-constraint
+ ```
+
+ #### How it works
+
+ - Hook takes all `yml` files.
+ - Paths of yaml files that contain exposure will be iterated over and checked if they match the path of the specified folder, given as argument.
+
+ -----
+
 ### `check-column-desc-are-same`
 
 Check the models have the same descriptions for the same column names.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ If this is the case, `pre-commit-dbt` is here to help you!
 
 **Exposure checks:**
  * [`check-exposure-has-models`](https://github.com/artefactory/pre-commit-dbt/blob/main/HOOKS.md#check-exposure-has-models): Check if the exposures depends on at least one model
+ * [`check-exposure_folder_constraint`](https://github.com/artefactory/pre-commit-dbt/blob/main/HOOKS.md#check-exposure_folder_constraint): Ensures exposures are only defined in a given folder X.
 
 **Model checks:**
  * [`check-column-desc-are-same`](https://github.com/offbi/pre-commit-dbt/blob/main/HOOKS.md#check-column-desc-are-same): Check column descriptions are the same.

--- a/pre_commit_dbt/check_exposure_folder_constraint.py
+++ b/pre_commit_dbt/check_exposure_folder_constraint.py
@@ -1,0 +1,43 @@
+import argparse
+from pathlib import Path
+from typing import Optional
+from typing import Sequence
+
+from pre_commit_dbt.utils import add_filenames_args
+from pre_commit_dbt.utils import get_exposure_paths
+
+def check_exposure_path(paths: Sequence[str], exposure_folder_path: str) -> int:
+    """
+    Checks if exposures are defined in the folder specified by the user
+    Arguments:
+        paths: a sequence of paths
+        exposure_folder_path: string that represents the specified folder's path
+    Returns:
+        A status code (0 if the exposures are placed in the correct folder and 1 otherwise)
+    """
+    status_code = 0
+    ymls = [Path(path) for path in paths]
+
+    exposure_paths = get_exposure_paths(ymls)
+    misplaced_exposures = {exposure.exposure_path for exposure in exposure_paths if exposure_folder_path not in str(exposure.exposure_path)}
+    for misplaced_exposure in misplaced_exposures:
+        status_code = 1
+        print(
+            f"{misplaced_exposure}: "
+            f"is not in the directory passed as argument for the hook",
+        )
+    return status_code
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser()
+    add_filenames_args(parser)
+    parser.add_argument(
+        "--exposure-folder",
+        required=True,
+        help="Directory in which exposures should be defined.",
+    )
+    args = parser.parse_args(argv)
+    return check_exposure_path(args.filenames, exposure_folder_path=args.exposure_folder)
+
+if __name__ == "__main__":
+    exit(main())

--- a/pre_commit_dbt/utils.py
+++ b/pre_commit_dbt/utils.py
@@ -77,6 +77,19 @@ class MacroSchema:
 
 
 @dataclass
+class ExposureSchema:
+    exposure_name: str
+    exposure_type: str
+    owner: Dict[str, Any]
+    filename: str
+    prefix: str = "exposure"
+
+@dataclass
+class ExposurePathSchema:
+    exposure_name: str
+    exposure_path: Path
+
+@dataclass
 class SourceSchema:
     source_name: str
     table_name: str
@@ -123,6 +136,16 @@ def paths_to_dbt_models(
 ) -> List[str]:
     return [prefix + Path(path).stem + postfix for path in paths]
 
+def get_exposure_paths(yml_files: Sequence[Path]) -> Generator[ExposurePathSchema, None, None]:
+    for yml_file in yml_files:
+        exposures = yaml.safe_load(yml_file.open()).get("exposures", [])
+        for exposure in exposures:
+            exposure_name = exposure.get("name")
+            exposure_path = yml_file
+            yield ExposurePathSchema(
+                    exposure_name=exposure_name,
+                    exposure_path=exposure_path
+                ) 
 
 def get_json(json_filename: str) -> Dict[str, Any]:
     try:

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ console_scripts =
     check-column-desc-are-same = pre_commit_dbt.check_column_desc_are_same:main
     check-column-name-contract = pre_commit_dbt.check_column_name_contract:main
     check-exposure-has-models = pre_commit_dbt.check_exposure_has_models:main
+    check-exposure-folder-constraint = pre_commit_dbt.check_exposure_folder_constraint:main
     check-macro-has-description = pre_commit_dbt.check_macro_has_description:main
     check-macro-arguments-have-desc = pre_commit_dbt.check_macro_arguments_have_desc:main
     check-model-columns-have-desc = pre_commit_dbt.check_model_columns_have_desc:main

--- a/tests/unit/test_check_exposure_folder_constraint.py
+++ b/tests/unit/test_check_exposure_folder_constraint.py
@@ -1,0 +1,73 @@
+import pytest
+import os
+
+from pre_commit_dbt.check_exposure_folder_constraint import main
+
+TESTS = (  # type: ignore
+    (
+        """
+version: 2
+
+exposures:
+  
+  - name: weekly_jaffle_metrics
+    type: dashboard
+    maturity: high
+    url: https://bi.tool/dashboards/1
+    description: >
+      Did someone say "exponential growth"?
+    
+    depends_on:
+      - ref('fct_orders')
+      - ref('dim_customers')
+      - source('gsheets', 'goals')
+      
+    owner:
+      name: Claire from Data
+      email: data@jaffleshop.com
+    """,
+        1,
+        "/models/sources.yml",
+        "sources",
+    ),
+    (
+        """
+version: 2
+
+exposures:
+  
+  - name: weekly_jaffle_metrics
+    type: dashboard
+    maturity: high
+    url: https://bi.tool/dashboards/1
+    description: >
+      Did someone say "exponential growth"?
+    
+    depends_on:
+      - ref('fct_orders')
+      - ref('dim_customers')
+      - source('gsheets', 'goals')
+      
+    owner:
+      name: Claire from Data
+      email: data@jaffleshop.com
+    """,
+        0,
+        "/models/sources.yml",
+        "models",
+    ),
+)
+
+@pytest.mark.parametrize(("schema_yml", "expected_status_code", "exposure_path", "desired_path"), TESTS)
+def test_check_source_folder_constraint(schema_yml, expected_status_code, exposure_path, desired_path, tmpdir):
+    exposure_dir=tmpdir.mkdir(exposure_path[:exposure_path.rfind(os.sep)]) # exposure_path[:exposure_path.rfind(os.sep)] would return the path without the names of the yaml file
+    yml_file = exposure_dir.join(exposure_path[exposure_path.rfind(os.sep):]) # exposure_path[exposure_path.rfind(os.sep):] would return the name of the yaml file
+    yml_file.write(schema_yml)
+    result = main(
+        argv=[
+            str(yml_file),
+            "--exposure-folder",
+            str(tmpdir.join(desired_path)),
+        ],
+    )
+    assert result == expected_status_code


### PR DESCRIPTION
**Implementation of the following policy:** _Exposures cannot be defined in a folder other than a given folder X._

### Test locally:
Modify line **43** as follows
`exit(main(argv=["path_to_your_file", "--exposure-folder", "path_to_your_desired_directory"]))`
where: 
* `path_to_your_file` is the path to the file containing the exposures
* `path_to_your_desired_directory` is the path to folder _X_ the exposures should be defined.

### Unit testing:
From the repo, run
`pytest tests/unit/test_check_source_exposure_constraint.py`